### PR TITLE
Add --brief argument to mapping commands

### DIFF
--- a/module/mapping/src/main/java/net/fabricmc/discord/bot/module/mapping/YarnClassCommand.java
+++ b/module/mapping/src/main/java/net/fabricmc/discord/bot/module/mapping/YarnClassCommand.java
@@ -46,7 +46,7 @@ public final class YarnClassCommand extends Command {
 
 	@Override
 	public String usage() {
-		return "<className> [latest | latestStable | <mcVersion>] [--ns=<nsList>] [--queryNs=<nsList>] [--displayNs=<nsList>]";
+		return "<className> [latest | latestStable | <mcVersion>] [--ns=<nsList>] [--queryNs=<nsList>] [--displayNs=<nsList>] [--brief]";
 	}
 
 	@Override
@@ -54,6 +54,8 @@ public final class YarnClassCommand extends Command {
 		String mcVersion = MappingCommandUtil.getMcVersion(context, arguments);
 		MappingData data = MappingCommandUtil.getMappingData(repo, mcVersion);
 		String name = arguments.get("className");
+
+		boolean brief = arguments.containsKey("brief");
 
 		List<String> queryNamespaces = MappingCommandUtil.getNamespaces(context, arguments, true);
 		Collection<ClassMapping> results = data.findClasses(name, data.resolveNamespaces(queryNamespaces, false));
@@ -72,7 +74,8 @@ public final class YarnClassCommand extends Command {
 		StringBuilder sb = new StringBuilder(400);
 
 		for (ClassMapping result : results) {
-			sb.append("**Names**\n\n");
+			if (!brief)
+				sb.append("**Names**\n\n");
 
 			for (String ns : namespaces) {
 				String res = result.getName(ns);
@@ -82,13 +85,15 @@ public final class YarnClassCommand extends Command {
 				}
 			}
 
-			sb.append(String.format("\n**Yarn Access Widener**\n\n```accessible\tclass\t%s```",
-					result.getName("yarn")));
+			if (!brief) {
+				sb.append(String.format("\n**Yarn Access Widener**\n\n```accessible\tclass\t%s```",
+						result.getName("yarn")));
 
-			URI javadocUrl = data.getJavadocUrl(result);
+				URI javadocUrl = data.getJavadocUrl(result);
 
-			if (javadocUrl != null) {
-				sb.append(String.format("\n**[Javadoc](%s)**", javadocUrl));
+				if (javadocUrl != null) {
+					sb.append(String.format("\n**[Javadoc](%s)**", javadocUrl));
+				}
 			}
 
 			builder.page(sb);

--- a/module/mapping/src/main/java/net/fabricmc/discord/bot/module/mapping/YarnMethodCommand.java
+++ b/module/mapping/src/main/java/net/fabricmc/discord/bot/module/mapping/YarnMethodCommand.java
@@ -46,7 +46,7 @@ public final class YarnMethodCommand extends Command {
 
 	@Override
 	public String usage() {
-		return "<methodName> [latest | latestStable | <mcVersion>] [--ns=<nsList>] [--queryNs=<nsList>] [--displayNs=<nsList>]";
+		return "<methodName> [latest | latestStable | <mcVersion>] [--ns=<nsList>] [--queryNs=<nsList>] [--displayNs=<nsList>] [--brief]";
 	}
 
 	@Override
@@ -54,6 +54,8 @@ public final class YarnMethodCommand extends Command {
 		String mcVersion = MappingCommandUtil.getMcVersion(context, arguments);
 		MappingData data = MappingCommandUtil.getMappingData(repo, mcVersion);
 		String name = arguments.get("methodName");
+
+		boolean brief = arguments.containsKey("brief");
 
 		List<String> queryNamespaces = MappingCommandUtil.getNamespaces(context, arguments, true);
 		Collection<MethodMapping> results = data.findMethods(name, data.resolveNamespaces(queryNamespaces, false));
@@ -72,37 +74,48 @@ public final class YarnMethodCommand extends Command {
 		StringBuilder sb = new StringBuilder(400);
 
 		for (MethodMapping result : results) {
-			sb.append("**Class Names**\n\n");
+			if (brief) {
+				for (String ns : namespaces) {
+					String owner = result.getOwner().getName(ns);
+					String member = result.getName(ns);
 
-			for (String ns : namespaces) {
-				String res = result.getOwner().getName(ns);
-
-				if (res != null) {
-					sb.append(String.format("**%s:** `%s`\n", FormatUtil.capitalize(ns), res));
+					if (owner != null && member != null) {
+						sb.append(String.format("**%s:** `%s.%s`\n", FormatUtil.capitalize(ns), owner, member));
+					}
 				}
-			}
+			} else {
+				sb.append("**Class Names**\n\n");
 
-			sb.append("\n**Method Names**\n\n");
+				for (String ns : namespaces) {
+					String res = result.getOwner().getName(ns);
 
-			for (String ns : namespaces) {
-				String res = result.getName(ns);
-
-				if (res != null) {
-					sb.append(String.format("**%s:** `%s`\n", FormatUtil.capitalize(ns), result.getName(ns)));
+					if (res != null) {
+						sb.append(String.format("**%s:** `%s`\n", FormatUtil.capitalize(ns), res));
+					}
 				}
-			}
 
-			sb.append(String.format("\n**Yarn Method Descriptor**\n\n```%3$s```\n"
-					+ "**Yarn Access Widener**\n\n```accessible\tmethod\t%1$s\t%2$s\t%3$s```\n"
-					+ "**Yarn Mixin Target**\n\n```L%1$s;%2$s%3$s```",
-					result.getOwner().getName("yarn"),
-					result.getName("yarn"),
-					result.getDesc("yarn")));
+				sb.append("\n**Method Names**\n\n");
 
-			URI javadocUrl = data.getJavadocUrl(result);
+				for (String ns : namespaces) {
+					String res = result.getName(ns);
 
-			if (javadocUrl != null) {
-				sb.append(String.format("\n**[Javadoc](%s)**", javadocUrl));
+					if (res != null) {
+						sb.append(String.format("**%s:** `%s`\n", FormatUtil.capitalize(ns), result.getName(ns)));
+					}
+				}
+
+				sb.append(String.format("\n**Yarn Method Descriptor**\n\n```%3$s```\n"
+								+ "**Yarn Access Widener**\n\n```accessible\tmethod\t%1$s\t%2$s\t%3$s```\n"
+								+ "**Yarn Mixin Target**\n\n```L%1$s;%2$s%3$s```",
+						result.getOwner().getName("yarn"),
+						result.getName("yarn"),
+						result.getDesc("yarn")));
+
+				URI javadocUrl = data.getJavadocUrl(result);
+
+				if (javadocUrl != null) {
+					sb.append(String.format("\n**[Javadoc](%s)**", javadocUrl));
+				}
 			}
 
 			builder.page(sb);


### PR DESCRIPTION
This PR adds a `--brief` argument to `!yarnclass`, `!yarnfield` and `!yarnmethod`.
This argument omits descriptors, access wideners and JavaDoc links from the response.
It displays members in the format of `Owner.member` and is meant to be used in support channels without flooding the chat.