### PR TITLE
Validate tag arguments

### DIFF
--- a/module/tag/src/main/java/net/fabricmc/discord/bot/module/tag/TagModule.java
+++ b/module/tag/src/main/java/net/fabricmc/discord/bot/module/tag/TagModule.java
@@ -163,10 +163,14 @@ public final class TagModule implements Module, CommandStringHandler {
 						logger.warn("Text tag {} doesn't have any content, skipping", entry.name());
 						continue;
 					} else if (entry.messageContent().contains("{{")) {
+						logger.warn("Text tag {} has a parameter, set type to \"parameterized\" instead", entry.name());
 						tag = new TagInstance.ParameterizedText(entry.name(), entry.messageContent());
 					} else {
 						tag = new TagInstance.PlainText(entry.name(), entry.messageContent());
 					}
+				} else if (entry.frontMatter() instanceof TagFrontMatter.ParameterizedText) {
+					TagFrontMatter.ParameterizedText parameterized = (TagFrontMatter.ParameterizedText)entry.frontMatter();
+					tag = new TagInstance.ParameterizedText(entry.name(), parameterized.validators(), entry.messageContent());
 				} else if (entry.frontMatter() instanceof TagFrontMatter.Alias) {
 					postponedEntries.add(entry);
 					continue; // handle later since the referenced tag may not be loaded yet

--- a/tag-parser/src/main/java/net/fabricmc/tag/TagFrontMatter.java
+++ b/tag-parser/src/main/java/net/fabricmc/tag/TagFrontMatter.java
@@ -16,11 +16,17 @@
 
 package net.fabricmc.tag;
 
+import java.util.List;
+import java.util.function.Predicate;
+
 import org.javacord.api.entity.message.embed.EmbedBuilder;
 
 public interface TagFrontMatter {
 	TagFrontMatter TEXT = new TagFrontMatter() {
 	};
+
+	record ParameterizedText(List<Predicate<String>> validators) implements TagFrontMatter {
+	}
 
 	record Alias(String target) implements TagFrontMatter {
 	}


### PR DESCRIPTION
Validation is opt-in; a tag needs to have type "parameterized". The number of validators (list of RegEx patterns declared in `validators` field) must match the number of placeholders in the text.