### PR TITLE
Add private channels instead of DM only for private namespaces

### DIFF
--- a/module/mapping/src/main/java/net/fabricmc/discord/bot/module/mapping/MappingCommandUtil.java
+++ b/module/mapping/src/main/java/net/fabricmc/discord/bot/module/mapping/MappingCommandUtil.java
@@ -108,7 +108,7 @@ final class MappingCommandUtil {
 		// trim to allowed only
 		boolean removedPrivateNs = false;
 
-		if (checkPublic && !context.isPrivateMessage()) {
+		if (checkPublic && Command.getConfig(context, MappingModule.PRIVATE_CHANNELS).contains(context.channel().getId())) {
 			List<String> privateNs = getPrivateNamespaces(context, ret);
 
 			if (!privateNs.isEmpty()) {
@@ -125,7 +125,7 @@ final class MappingCommandUtil {
 			ret.retainAll(MappingModule.supportedNamespaces);
 		}
 
-		if (ret.isEmpty()) throw new CommandException(removedPrivateNs ? "all selected namespaces are DM only" : "no valid namespaces");
+		if (ret.isEmpty()) throw new CommandException(removedPrivateNs ? "all selected namespaces are not available in the current channel" : "no valid namespaces");
 
 		return ret;
 	}

--- a/module/mapping/src/main/java/net/fabricmc/discord/bot/module/mapping/MappingModule.java
+++ b/module/mapping/src/main/java/net/fabricmc/discord/bot/module/mapping/MappingModule.java
@@ -33,10 +33,12 @@ public final class MappingModule implements Module {
 	static final List<String> supportedNamespaces = List.of("official", "intermediary", "yarn", "mojmap", "srg", "mcp");
 	private static final List<String> defaultNamespaces = List.of("official", "intermediary", "yarn");
 	private static final List<String> publicNamespaces = defaultNamespaces;
+	private static final List<Long> privateChannels = List.of(521545796882006027L); // #yarn on fabricord
 
 	// global properties
 	static final ConfigKey<List<String>> DEFAULT_NAMESPACES = new ConfigKey<>("mapping.defaultNamespaces", ValueSerializers.STRING_LIST);
 	static final ConfigKey<List<String>> PUBLIC_NAMESPACES = new ConfigKey<>("mapping.publicNamespaces", ValueSerializers.STRING_LIST);
+	static final ConfigKey<List<Long>> PRIVATE_CHANNELS = new ConfigKey<>("mapping.privateChannels", ValueSerializers.LONG_LIST);
 
 	// user properties
 	static final ConfigKey<List<String>> QUERY_NAMESPACES = new ConfigKey<>("mapping.queryNamespaces", ValueSerializers.STRING_LIST);
@@ -58,6 +60,7 @@ public final class MappingModule implements Module {
 	public void registerConfigEntries(DiscordBot bot) {
 		bot.registerConfigEntry(DEFAULT_NAMESPACES, () -> defaultNamespaces);
 		bot.registerConfigEntry(PUBLIC_NAMESPACES, () -> publicNamespaces);
+		bot.registerConfigEntry(PRIVATE_CHANNELS, () -> privateChannels);
 	}
 
 	@Override


### PR DESCRIPTION
Fabric changed the rules a while back to allow proprietary mappings to be sent in the server. However, the fabric bot still refuses to receive or display any proprietary mappings. This pr makes proprietary mappings available outside of DMs except for private channels, which can be configured and currently only consist of #yarn on fabricord.

Not tested. I'm not sure how to test this.