### PR TITLE
Fix new MC version announcements

### DIFF
--- a/module/mcversion/src/main/java/net/fabricmc/discord/bot/module/mcversion/LauncherNewsFetcher.java
+++ b/module/mcversion/src/main/java/net/fabricmc/discord/bot/module/mcversion/LauncherNewsFetcher.java
@@ -71,7 +71,7 @@ final class LauncherNewsFetcher {
 		fetchLatest();
 		Version latest = latestRelease.date.isAfter(latestSnapshot.date) ? latestRelease : latestSnapshot;
 
-		if (latest.date.isAfter(lastAnnounceTime) && !McVersionModule.isOldVersion(latest.name) && announce(latest)) {
+		if (latest.date.isAfter(lastAnnounceTime) && announce(latest)) {
 			lastAnnounceTime = latest.date;
 		}
 	}

--- a/module/mcversion/src/main/java/net/fabricmc/discord/bot/module/mcversion/McVersionModule.java
+++ b/module/mcversion/src/main/java/net/fabricmc/discord/bot/module/mcversion/McVersionModule.java
@@ -52,7 +52,6 @@ import net.fabricmc.discord.io.Server;
  * <ol>
  * <li>grab latest MC version from the launcher metadata API
  * <li>require that the version is not the same as in the bot DB
- * <li>require that Fabric Meta's intermediary records don't already list the version, indicating a bogus detection
  * <li>require that the version hasn't been announced by the bot's current process
  * <li>announce the version to the configured channel
  * <li>publish that announcement if possible
@@ -68,9 +67,6 @@ public final class McVersionModule implements Module {
 	static final String KIND_RELEASE = "release";
 	static final String KIND_SNAPSHOT = "snapshot";
 	static final String KIND_PENDING = "pending";
-
-	private static final String FABRIC_VERSION_HOST = "meta.fabricmc.net";
-	private static final String FABRIC_VERSION_PATH = "/v2/versions/intermediary/%s";
 
 	private static final Logger LOGGER = LogManager.getLogger(McVersionModule.class);
 
@@ -220,7 +216,6 @@ public final class McVersionModule implements Module {
 
 		if (latestVersion == null // no version specified
 				|| latestVersion.equals(oldVersion = bot.getConfigEntry(announcedVersionKey)) // same as last announced
-				|| isOldVersion(latestVersion) // already known to Fabric, mcmeta glitch
 				|| announcedVersions.contains(latestVersion)) { // already posted by this instance
 			return;
 		}
@@ -242,23 +237,6 @@ public final class McVersionModule implements Module {
 
 		announcedVersions.add(latestVersion);
 		bot.setConfigEntry(announcedVersionKey, latestVersion);
-	}
-
-	static boolean isOldVersion(String version) throws IOException, URISyntaxException, InterruptedException {
-		if (version.indexOf('/') >= 0)  throw new IllegalArgumentException("invalid mc version: "+version);
-
-		HttpResponse<InputStream> response = HttpUtil.makeRequest(HttpUtil.toUri(FABRIC_VERSION_HOST, FABRIC_VERSION_PATH.formatted(version)));
-
-		if (response.statusCode() != 200) {
-			LOGGER.warn("MC version verification request against Fabric Meta failed: {}", response.statusCode());
-			response.body().close();
-			return false;
-		}
-
-		try (JsonReader reader = new JsonReader(new InputStreamReader(response.body(), StandardCharsets.UTF_8))) {
-			reader.beginArray();
-			return reader.hasNext();
-		}
 	}
 
 	boolean sendAnnouncement(Channel channel, String msg) {

--- a/module/mcversion/src/main/java/net/fabricmc/discord/bot/module/mcversion/NewsFetcher.java
+++ b/module/mcversion/src/main/java/net/fabricmc/discord/bot/module/mcversion/NewsFetcher.java
@@ -156,7 +156,7 @@ final class NewsFetcher {
 				&& !announcedNews.contains(path)) {
 			NewVersionUtil.Version version = NewVersionUtil.Version.get(matcher);
 
-			if (!hasAnnouncedSnapshot(version) && !McVersionModule.isOldVersion(version.toString())) {
+			if (!hasAnnouncedSnapshot(version)) {
 				LOGGER.info("Announcing MC-News {} (regular, version {})", path, version.toString());
 
 				if (!mcVersionModule.sendAnnouncement(mcVersionModule.getUpdateChannel(), "https://"+HOST+path)) {


### PR DESCRIPTION
Fixes the bot's inconsistency with announcing new MC versions by removing the Fabric meta intermediary check. This check worked fine before the deobfuscation as intermediary would take some time to be updated. But now that Fabric meta auto uploads a dummy intermediary jar, the bot will often fail to announce because Fabric meta likely updates first before the bot.

Removing it shouldn't cause any duplicate announcements as there are still quite a few other checks to prevent duplicates. Tho the bot's database config for `mcversion.announcedReleaseVersion` and `mcversion.announcedSnapshotVersion` probably have to be updated manually to prevent the most recent releases from triggering an announcement, as those values haven't been updated for a few snapshots now.