### PR TITLE
Fix LauncherNewsFetcher duplicate announcements

### DIFF
--- a/module/mcversion/src/main/java/net/fabricmc/discord/bot/module/mcversion/LauncherNewsFetcher.java
+++ b/module/mcversion/src/main/java/net/fabricmc/discord/bot/module/mcversion/LauncherNewsFetcher.java
@@ -26,9 +26,11 @@ import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
+import java.util.Collections;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.function.Predicate;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 import com.google.gson.stream.JsonReader;
@@ -46,6 +48,8 @@ final class LauncherNewsFetcher {
 	private static final String PATH = "/v2/javaPatchNotes.json";
 	private static final Logger LOGGER = LogManager.getLogger("mcversion/launcher");
 	private final McVersionModule mcVersionModule;
+	// sometimes MCLauncherNews may glitch and change the news datetime by a couple milliseconds, so use this as an extra failsafe
+	private final Set<String> announcedVersions = Collections.newSetFromMap(new ConcurrentHashMap<>());
 	private Version latestRelease;
 	private Version latestSnapshot;
 	private long lastUpdateTimeMs = System.currentTimeMillis();
@@ -67,12 +71,18 @@ final class LauncherNewsFetcher {
 		return lastUpdateTimeMs;
 	}
 
+	void init(String announcedRelease, String announcedSnapshot) {
+		announcedVersions.add(announcedRelease);
+		announcedVersions.add(announcedSnapshot);
+	}
+
 	void update() throws IOException, URISyntaxException, InterruptedException, DateTimeParseException {
 		fetchLatest();
 		Version latest = latestRelease.date.isAfter(latestSnapshot.date) ? latestRelease : latestSnapshot;
 
-		if (latest.date.isAfter(lastAnnounceTime) && announce(latest)) {
+		if (latest.date.isAfter(lastAnnounceTime) && !announcedVersions.contains(latest.name) && announce(latest)) {
 			lastAnnounceTime = latest.date;
+			announcedVersions.add(latest.name);
 		}
 	}
 

--- a/module/mcversion/src/main/java/net/fabricmc/discord/bot/module/mcversion/McVersionModule.java
+++ b/module/mcversion/src/main/java/net/fabricmc/discord/bot/module/mcversion/McVersionModule.java
@@ -162,7 +162,11 @@ public final class McVersionModule implements Module {
 		this.announceChannel = getChannel(server, "announce", bot.getConfigEntry(ANNOUNCE_CHANNEL));
 		this.updateChannel = getChannel(server, "update", bot.getConfigEntry(UPDATE_CHANNEL));
 
-		newsFetcher.init(bot.getConfigEntry(ANNOUNCED_SNAPSHOT_VERSION));
+		String announcedRelease = bot.getConfigEntry(ANNOUNCED_RELEASE_VERSION);
+		String announcedSnapshot = bot.getConfigEntry(ANNOUNCED_SNAPSHOT_VERSION);
+
+		newsFetcher.init(announcedSnapshot);
+		launcherNewsFetcher.init(announcedRelease, announcedSnapshot);
 
 		if (announceChannel != null || updateChannel != null) {
 			future = bot.getScheduledExecutor().scheduleWithFixedDelay(this::update, 0, UPDATE_DELAY, TimeUnit.SECONDS);


### PR DESCRIPTION
LauncherNewsFetcher currently only relies on datetime to determine if a new announcement should be made. This would be fine but it seems that the `date` field from the Mojang launcher news API may randomly be updated by a few milliseconds for no apparent reason.

I verified this by checking Discord's network requests for the embed's exact timestamp. The duplicate announcement embed timestamp matches up with 26.3-snapshot 4's entry from https://launchercontent.mojang.com/v2/javaPatchNotes.json

<img width="1174" height="780" alt="fabric bot ori announce" src="https://github.com/user-attachments/assets/3fb25bbb-69e6-483a-8608-16df829efed8" />
---
<img width="1268" height="889" alt="fabric bot dupe announce" src="https://github.com/user-attachments/assets/393e6bf5-effd-4572-a18c-f3fe3285f12e" />
